### PR TITLE
fix sample_label check

### DIFF
--- a/R/master.R
+++ b/R/master.R
@@ -100,7 +100,7 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 				 print(names(single_obj_list))
 				 stop("Sample label in comb_obj doesn't match names(new_group_list) or names(single_obj_list).")
 				 }
-
+			print(names(new_group_list))
 			new_group_list$comb <- recolor_comb(comb_obj, new_group_list, output, comb_delim, reduction=reduction)
 
 			coord <- as.data.frame(comb_obj@reductions[[reduction]]@cell.embeddings)

--- a/R/master.R
+++ b/R/master.R
@@ -100,7 +100,7 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 				 print(names(single_obj_list))
 				 stop("Sample label in comb_obj doesn't match names(new_group_list) or names(single_obj_list).")
 				 }
-			print(names(new_group_list))
+			return(new_group_list)
 			new_group_list$comb <- recolor_comb(comb_obj, new_group_list, output, comb_delim, reduction=reduction)
 
 			coord <- as.data.frame(comb_obj@reductions[[reduction]]@cell.embeddings)

--- a/R/master.R
+++ b/R/master.R
@@ -92,7 +92,7 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 		if (!is.null(comb_obj))
 		{
 			sample_label <- as.factor(sub(paste0(comb_delim, '.*'), '', rownames(comb_obj@meta.data)))
-			if (all(levels(sample_label) == names(new_group_list)) == FALSE)
+			if (all(sort(levels(sample_label)) == sort(names(new_group_list))) == FALSE)
 				{
 				 message("Sample label in comb_obj: ")
 				 print(levels(sample_label))

--- a/R/master.R
+++ b/R/master.R
@@ -77,6 +77,7 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 		circos_map(mapRes, cell_num_list, output)
 		mapRes <- add_perc(mapRes, cell_num_list)
 	}
+	return(mapRes)
 
 	## Recolor reduction plot for each sample if single Seurat object list is provided.
 	if (!is.null(single_obj_list))
@@ -86,7 +87,6 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 			da <- structure(as.vector(mapRes[, n]), names = mapRes$regroup)
 			recolor_s(da, single_obj_list[[n]], n, reduction=reduction)
 		})
-		return(new_group_list)
 		names(new_group_list) <- names(single_obj_list)
 
 		## Recolor reduction plot for combined sample and calculate separability if combined Seurat object is provided.

--- a/R/master.R
+++ b/R/master.R
@@ -101,7 +101,7 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 				 stop("Sample label in comb_obj doesn't match names(new_group_list) or names(single_obj_list).")
 				 }
 
-			new_group_list$comb <- recolor_comb(comb_obj, new_group_list, output, comb_delim)
+			new_group_list$comb <- recolor_comb(comb_obj, new_group_list, output, comb_delim, reduction)
 
 			coord <- as.data.frame(comb_obj@reductions[[reduction]]@cell.embeddings)
 			sepa <- separability_pairwise(coord, group = new_group_list$comb, sample_label, k = k)

--- a/R/master.R
+++ b/R/master.R
@@ -86,6 +86,7 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 			da <- structure(as.vector(mapRes[, n]), names = mapRes$regroup)
 			recolor_s(da, single_obj_list[[n]], n, reduction=reduction)
 		})
+		return(new_group_list)
 		names(new_group_list) <- names(single_obj_list)
 
 		## Recolor reduction plot for combined sample and calculate separability if combined Seurat object is provided.
@@ -100,7 +101,7 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 				 print(names(single_obj_list))
 				 stop("Sample label in comb_obj doesn't match names(new_group_list) or names(single_obj_list).")
 				 }
-			return(new_group_list)
+			
 			new_group_list$comb <- recolor_comb(comb_obj, new_group_list, output, comb_delim, reduction=reduction)
 
 			coord <- as.data.frame(comb_obj@reductions[[reduction]]@cell.embeddings)

--- a/R/master.R
+++ b/R/master.R
@@ -101,7 +101,7 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 				 stop("Sample label in comb_obj doesn't match names(new_group_list) or names(single_obj_list).")
 				 }
 
-			new_group_list$comb <- recolor_comb(comb_obj, new_group_list, output, comb_delim, reduction)
+			new_group_list$comb <- recolor_comb(comb_obj, new_group_list, output, comb_delim, reduction=reduction)
 
 			coord <- as.data.frame(comb_obj@reductions[[reduction]]@cell.embeddings)
 			sepa <- separability_pairwise(coord, group = new_group_list$comb, sample_label, k = k)

--- a/R/master.R
+++ b/R/master.R
@@ -93,11 +93,12 @@ cluster_map <- function(marker_file_list, edge_cutoff = 0.1, output, cell_num_li
 		{
 			sample_label <- as.factor(sub(paste0(comb_delim, '.*'), '', rownames(comb_obj@meta.data)))
 			if (all(levels(sample_label) == names(new_group_list)) == FALSE)
-				{stop("Sample label in comb_obj doesn't match names(new_group_list) or names(single_obj_list).")
+				{
 				 message("Sample label in comb_obj: ")
 				 print(levels(sample_label))
 				 message("names(single_obj_list): ")
 				 print(names(single_obj_list))
+				 stop("Sample label in comb_obj doesn't match names(new_group_list) or names(single_obj_list).")
 				 }
 
 			new_group_list$comb <- recolor_comb(comb_obj, new_group_list, output, comb_delim)

--- a/R/recolor.R
+++ b/R/recolor.R
@@ -106,7 +106,7 @@ recolor_comb <- function(comb_obj, new_group_list, output, comb_delim = '-', col
 	print(levels(sample_label))
 	message("names(new_group_list):")
 	print(names(new_group_list))
-    if (all(levels(sample_label) == names(new_group_list)) == FALSE)
+    if (all(sort(levels(sample_label)) == sort(names(new_group_list))) == FALSE)
 		stop("Sample label in comb_obj doesn't match names(new_group_list) or names(single_obj_list).")
 	names(sample_label) <- colnames(GetAssayData(object = comb_obj))
 	## color by samples


### PR DESCRIPTION
Referencing #17
- Add ``sort()`` to label check
- Move info print before ``stop()`` for debugging
- Pass ``reduction``  to ``recolor_comb`` when called from ``cluster_map``

From my understanding, cell labels in the combined object have to be in the format of ``SAMPLE_LABEL[-/_]ORIGINAL_CELL_LABEL``. The fix is working for my own data.